### PR TITLE
Update Github Action to build & push multi-platform images

### DIFF
--- a/.github/workflows/multi-platform-docker-build.yml
+++ b/.github/workflows/multi-platform-docker-build.yml
@@ -2,8 +2,14 @@ name: crtsh-exporter-multi-platform-docker-build
 
 on:
   push:
+    # tags:
+    #   - "v*.*.*" 
     branches:
       - master
+
+  schedule:
+    # This will run at 11:00 PM UTC every Monday.
+    - cron: '0 23 * * 1'
 jobs:
   crtsh-exporter-multi-platform-docker-build:
     name: crtsh-exporter

--- a/.github/workflows/multi-platform-docker-build.yml
+++ b/.github/workflows/multi-platform-docker-build.yml
@@ -1,0 +1,104 @@
+name: crtsh-exporter-multi-platform-docker-build
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  crtsh-exporter-multi-platform-docker-build:
+    name: crtsh-exporter
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: "ghcr.io" 
+      REPO: "${{ github.repository_owner }}/crtsh-exporter" 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set SHA_SHORT env var and get Kernel version
+        id: vars
+        run: |
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> ${GITHUB_ENV}
+          echo "VERSION=$(uname --kernel-release)" >> ${GITHUB_ENV}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR }}
+          
+      - name: Buildx linux/amd64 Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          build-args: |
+            VERSION=${{ env.SHA_SHORT }}
+            COMMIT=${{ env.REPO }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPO }}:${{ env.SHA_SHORT }},${{ env.REGISTRY }}/${{ env.REPO }}:latest
+
+      - name: Buildx linux/arm64 Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/arm64
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            COMMIT=${{ env.SHA_SHORT }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPO }}:${{ env.SHA_SHORT }},${{ env.REGISTRY }}/${{ env.REPO }}:latest
+
+      - name: Buildx linux/arm64/v8 Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/arm64/v8
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            COMMIT=${{ github.sha }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REPO }}:${{ env.SHA_SHORT }},${{ env.REGISTRY }}/${{ env.REPO }}:latest
+        continue-on-error: true  
+
+
+      # - name: Install Cosign
+      #   uses: sigstore/cosign-installer@main
+      # - name: Write signing key to disk (only needed for `cosign sign --key`)
+      #   run: echo "${{ secrets.SIGNING }}" > ./cosign.key
+      # - name: Sign container image
+      #   run: |
+      #     cosign sign \
+      #     --yes \
+      #     --key=./cosign.key \
+      #     --annotations="repo=${{ github.repository }}" \
+      #     --annotations="workflow=${{ github.workflow }}" \
+      #     --annotations="commit=${{ github.sha }}" \
+      #     --annotations="version=${{ env.VERSION }}" \
+      #     ghcr.io/${{ env.REPO }}@${{ steps.docker-build-push.outputs.digest }}
+      #   env:
+      #     COSIGN_PASSWORD: ""
+      
+      # - name: revise occurrences of the image
+      #   run: |
+      #     git config --local user.email "action@github.com"
+      #     git config --local user.name "GitHub Actions"
+
+      #     for FILENAME in "./README.md"
+      #     do
+      #       sed \
+      #       --in-place \
+      #       "s|ghcr.io/${{ env.REPO }}:[0-9a-f]\{40\}|ghcr.io/${{ env.REPO }}:${{ github.sha }}|g" \
+      #       ${FILENAME}
+      #       git add ${FILENAME}
+      #     done
+
+      #     git commit --message "GitHub Actions update image references"
+      #     git push origin master

--- a/.github/workflows/multi-platform-docker-build.yml
+++ b/.github/workflows/multi-platform-docker-build.yml
@@ -75,36 +75,36 @@ jobs:
         continue-on-error: true  
 
 
-      # - name: Install Cosign
-      #   uses: sigstore/cosign-installer@main
-      # - name: Write signing key to disk (only needed for `cosign sign --key`)
-      #   run: echo "${{ secrets.SIGNING }}" > ./cosign.key
-      # - name: Sign container image
-      #   run: |
-      #     cosign sign \
-      #     --yes \
-      #     --key=./cosign.key \
-      #     --annotations="repo=${{ github.repository }}" \
-      #     --annotations="workflow=${{ github.workflow }}" \
-      #     --annotations="commit=${{ github.sha }}" \
-      #     --annotations="version=${{ env.VERSION }}" \
-      #     ghcr.io/${{ env.REPO }}@${{ steps.docker-build-push.outputs.digest }}
-      #   env:
-      #     COSIGN_PASSWORD: ""
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+      - name: Write signing key to disk (only needed for `cosign sign --key`)
+        run: echo "${{ secrets.SIGNING }}" > ./cosign.key
+      - name: Sign container image
+        run: |
+          cosign sign \
+          --yes \
+          --key=./cosign.key \
+          --annotations="repo=${{ github.repository }}" \
+          --annotations="workflow=${{ github.workflow }}" \
+          --annotations="commit=${{ github.sha }}" \
+          --annotations="version=${{ env.VERSION }}" \
+          ghcr.io/${{ env.REPO }}@${{ steps.docker-build-push.outputs.digest }}
+        env:
+          COSIGN_PASSWORD: ""
       
-      # - name: revise occurrences of the image
-      #   run: |
-      #     git config --local user.email "action@github.com"
-      #     git config --local user.name "GitHub Actions"
+      - name: revise occurrences of the image
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Actions"
 
-      #     for FILENAME in "./README.md"
-      #     do
-      #       sed \
-      #       --in-place \
-      #       "s|ghcr.io/${{ env.REPO }}:[0-9a-f]\{40\}|ghcr.io/${{ env.REPO }}:${{ github.sha }}|g" \
-      #       ${FILENAME}
-      #       git add ${FILENAME}
-      #     done
+          for FILENAME in "./README.md"
+          do
+            sed \
+            --in-place \
+            "s|ghcr.io/${{ env.REPO }}:[0-9a-f]\{40\}|ghcr.io/${{ env.REPO }}:${{ github.sha }}|g" \
+            ${FILENAME}
+            git add ${FILENAME}
+          done
 
-      #     git commit --message "GitHub Actions update image references"
-      #     git push origin master
+          git commit --message "GitHub Actions update image references"
+          git push origin master

--- a/.github/workflows/multi-platform-docker-build.yml
+++ b/.github/workflows/multi-platform-docker-build.yml
@@ -47,7 +47,7 @@ jobs:
           platforms: linux/amd64
           build-args: |
             VERSION=${{ env.SHA_SHORT }}
-            COMMIT=${{ env.REPO }}
+            COMMIT=${{ github.sha }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPO }}:${{ env.SHA_SHORT }},${{ env.REGISTRY }}/${{ env.REPO }}:latest
 
@@ -58,7 +58,7 @@ jobs:
           platforms: linux/arm64
           build-args: |
             VERSION=${{ env.VERSION }}
-            COMMIT=${{ env.SHA_SHORT }}
+            COMMIT=${{ github.sha }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPO }}:${{ env.SHA_SHORT }},${{ env.REGISTRY }}/${{ env.REPO }}:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 ARG GOLANG_VERSION=1.22.0
 
-ARG GOOS=linux
-ARG GOARCH=amd64
+# TARGETOS and TARGETARCH will be populated at 'docker build'
+ARG TARGETOS  
+ARG TARGETARCH
 
 ARG COMMIT
 ARG VERSION
 
-FROM docker.io/golang:${GOLANG_VERSION} as build
+FROM docker.io/golang:${GOLANG_VERSION} AS build
 
 WORKDIR /crtsh-exporter
 
@@ -14,13 +15,14 @@ COPY go.* ./
 COPY main.go .
 COPY collector ./collector
 
-ARG GOOS
-ARG GOARCH
-
+# TARGETOS and TARGETARCH will be populated at 'docker build'
+ARG TARGETOS  
+ARG TARGETARCH
+ 
 ARG VERSION
 ARG COMMIT
 
-RUN CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build \
     -ldflags "-X main.OSVersion=${VERSION} -X main.GitCommit=${COMMIT}" \
     -a -installsuffix cgo \
@@ -29,8 +31,8 @@ RUN CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} \
 
 FROM gcr.io/distroless/static-debian12:latest
 
-LABEL org.opencontainers.image.description "Prometheus Exporter for crt.sh"
-LABEL org.opencontainers.image.source https://github.com/DazWilkin/crtsh-exporter
+LABEL org.opencontainers.image.description="Prometheus Exporter for crt.sh"
+LABEL org.opencontainers.image.source=https://github.com/DazWilkin/crtsh-exporter
 
 COPY --from=build /go/bin/exporter /
 


### PR DESCRIPTION
The Dockerfile is primed for multi-arch builds but GA would only build `linux/amd64` images.

I've added `docker buildx` tasks to build Docker Images for following platforms:

- `linux/amd64`
- `linux/arm64`
- `linux/arm64/v8`


Note: Image Sign tasks are commented out. 