### PR TITLE
Fix multi platform image build GA pipeline

### DIFF
--- a/.github/workflows/multi-platform-docker-build.yml
+++ b/.github/workflows/multi-platform-docker-build.yml
@@ -40,43 +40,17 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR }}
           
-      - name: Buildx linux/amd64 Docker Image
-        id: docker-build-push-amd64
+      - name: Buildx Multi Platform Linux Docker Images
+        id: docker-build-push-multi-platform
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64/v7,linux/arm64
           build-args: |
             VERSION=${{ env.SHA_SHORT }}
             COMMIT=${{ github.sha }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPO }}:${{ env.SHA_SHORT }},${{ env.REGISTRY }}/${{ env.REPO }}:latest
-
-      - name: Buildx linux/arm64 Docker Image
-        id: docker-build-push-arm64
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/arm64
-          build-args: |
-            VERSION=${{ env.VERSION }}
-            COMMIT=${{ github.sha }}
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPO }}:${{ env.SHA_SHORT }},${{ env.REGISTRY }}/${{ env.REPO }}:latest
-
-      - name: Buildx linux/arm64/v8 Docker Image
-        id: docker-build-push-arm64-v8
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/arm64/v8
-          build-args: |
-            VERSION=${{ env.VERSION }}
-            COMMIT=${{ github.sha }}
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPO }}:${{ env.SHA_SHORT }},${{ env.REGISTRY }}/${{ env.REPO }}:latest
-        continue-on-error: true  
-
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@main
@@ -85,9 +59,7 @@ jobs:
       - name: Sign container image
         run: |
           DIGESTS=(
-            ${{ steps.docker-build-push-amd64.digest }}
-            ${{ steps.docker-build-push-arm64.digest }}
-            ${{ steps.docker-build-push-arm64-v8.digest }}
+            ${{ steps.docker-build-push-multi-platform.digest }}
           )
           for DIGEST in "${DIGESTS[@]}"
           do
@@ -102,7 +74,7 @@ jobs:
           done
         env:
           COSIGN_PASSWORD: ""
-      
+
       - name: revise occurrences of the image
         run: |
           git config --local user.email "action@github.com"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETARCH
 ARG COMMIT
 ARG VERSION
 
-FROM docker.io/golang:${GOLANG_VERSION} AS build
+FROM --platform=$TARGETARCH docker.io/golang:${GOLANG_VERSION} AS build
 
 WORKDIR /crtsh-exporter
 
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     -o /go/bin/exporter \
     ./main.go
 
-FROM gcr.io/distroless/static-debian12:latest
+FROM --platform=$TARGETARCH gcr.io/distroless/static-debian12:latest
 
 LABEL org.opencontainers.image.description="Prometheus Exporter for crt.sh"
 LABEL org.opencontainers.image.source=https://github.com/DazWilkin/crtsh-exporter


### PR DESCRIPTION
**Changes:**
- Added `FROM --platform=$TARGETARCH` to Dockerfile stages
- Changed `linux/arm64/v8` to `linux/arm64/v7` as QEMU won't support above v7 
- Gathered all buildx tasks to single tasks
  - Turns out this is important to set proper metadata, 
  - and no timeouts happened
- Tested on my account to fix the problem
  - <https://github.com/users/oguzhan-yilmaz/packages/container/crtsh-exporter/> -> Go to `OS/Arch` tab and see
  - GA run: <https://github.com/oguzhan-yilmaz/crtsh-exporter/actions/runs/11891729044/job/33133083694>
- `arm64/v7` Runs on my M1 Macbook
    ```bash
    ❯ docker run ghcr.io/oguzhan-yilmaz/crtsh-exporter:latest
    {"time":"2024-11-18T11:51:18.736045667Z","level":"INFO","msg":"Server starting","endpoint":"0.0.0.0:8080"}
    {"time":"2024-11-18T11:51:18.737393667Z","level":"INFO","msg":"metrics path","path":"/metrics"}
    ```